### PR TITLE
use `MutationObserver` to update on changes

### DIFF
--- a/Programming/Remove KCal/removekcal-ff/removekcal.js
+++ b/Programming/Remove KCal/removekcal-ff/removekcal.js
@@ -1,32 +1,40 @@
 function getAllTextNodes() {
-    var walker = document.createTreeWalker(
-        document.body, 
-        NodeFilter.SHOW_TEXT, 
-        null, 
-        false
-    );
+  var walker = document.createTreeWalker(
+    document.body,
+    NodeFilter.SHOW_TEXT,
+    null,
+    false
+  );
 
-    var node;
-    var textNodes = [];
+  var node;
+  var textNodes = [];
 
-    while(node = walker.nextNode()) {
-        textNodes.push(node);
-    }
-    return textNodes;
+  while (node = walker.nextNode()) {
+    textNodes.push(node);
+  }
+  return textNodes;
 }
 
 function replaceNodes() {
-getAllTextNodes().forEach((node) => {
-  const { nodeValue } = node;
-  const newValue = nodeValue.replace(/[0-9]+[\s]*(kcal)/gi, 'x');
-  if (newValue !== nodeValue) {
-    node.nodeValue = newValue;
-  }
-});
-}
-document.onload = replaceNodes();
-for (let i = 0; i < 9; i++){
-  setTimeout(() => {document = replaceNodes(); }, 333);   // Required for sites that load weird
-                                                          // Hopefully will not be needed with a more robust solution
+  getAllTextNodes().forEach((node) => {
+    const { nodeValue } = node;
+    const newValue = nodeValue.replace(/[0-9]+[\s]*(kcal)/gi, 'x');
 
+    if (newValue !== nodeValue) {
+      node.nodeValue = newValue;
+    }
+  });
 }
+
+// run on page load
+document.addEventListener('DOMContentLoaded', replaceNodes);
+
+// use a MutationObserver to watch for DOM changes
+let observerConfig = {
+  subtree: true,
+  childList: true,
+  characterData: true
+};
+
+const observer = new MutationObserver(replaceNodes);
+observer.observe(document.body, observerConfig);


### PR DESCRIPTION
switch from using a timeout for running `replaceNodes` to using a `MutationObserver` to account for dynamically changing content.
This also switches to using `DOMContentLoaded` event instead of `onload` event to hide kcal information earlier in the rendering process.